### PR TITLE
Replace deprecated escape() function with encodeURI()

### DIFF
--- a/js/movie_browser.js
+++ b/js/movie_browser.js
@@ -3,7 +3,7 @@
 
 
 function search(keyword) {
-  var url = 'http://www.omdbapi.com/?s='+escape(keyword);
+  var url = 'http://www.omdbapi.com/?s=' + encodeURI(keyword);
 
   $.getJSON(url)
   .done(function(imdbResponse){


### PR DESCRIPTION
According to [Mozilla Developer Network documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape), the escape() function is deprecated and encodeURI or encodeURIComponent should be used instead. Looks like encodeURI has been in the spec since 1999 so there shouldn't be any browser compatibility issues at this point.
